### PR TITLE
Update workshops contact email, authors, submissions

### DIFF
--- a/2025/contribute/guidelines/authors.md
+++ b/2025/contribute/guidelines/authors.md
@@ -2,7 +2,7 @@
 layout: 2025/page
 title: Author Guidelines
 ---
-*Last updated: 2025-03-16 2:24PM GMT*
+*Last updated: 2025-03-17 2:57AM GMT*
 
 The guidelines cover all submitted papers to the single-track paper program. For more information on the specific tracks and associated deadlines, please see this year's [call for papers](/2025/contribute/papers).
 
@@ -13,11 +13,8 @@ ISMAR 2025 will host a **single track** for papers and include a revise and resu
 This year, there is one submission deadline for a unified review process for both the IEEE TVCG journal and the conference-only papers. The possible outcomes of this unified process are:
 
 -   Accept as IEEE TVCG paper, with the presentation at ISMAR 2025
-
 -   Accept as IEEE ISMAR 2025 conference paper, with presentation
-
 -   Recommend as IEEE ISMAR 2025 poster
-
 -   Reject
 
 ### Before Submission:

--- a/2025/contribute/guidelines/submissions.md
+++ b/2025/contribute/guidelines/submissions.md
@@ -2,19 +2,18 @@
 layout: 2025/page
 title: Submission Guidelines
 ---
-*Last updated: 2025-03-16 2:19PM GMT*
+*Last updated: 2025-03-17 2:57AM GMT*
 
 Please note that ISMAR 2025 has **only a single track.** For papers submitted to ISMAR there are **BOTH** abstract submission deadlines and full papers submission deadlines. See the [call for papers](/2025/contribute/papers) for specific dates. The use of a teaser image in papers is encouraged.
-All submissions must be done electronically via [PCS](https://new.precisionconference.com/ismar).
+
+**All submissions must be done electronically via [PCS](https://new.precisionconference.com/ismar)**.
 
 ## Abstract Deadline
 
 Prior to the respective track abstract deadline, authors are required to provide:
 
 - The paper title
-
 - Complete abstract
-
 - Authors
 
 If the abstract form is not completed at this time with the information detailed above, then a full paper will not be allowed to be submitted.
@@ -24,7 +23,6 @@ If the abstract form is not completed at this time with the information detailed
 Prior to the respective track deadline, authors of submitted abstracts are required to provide:
 
 - A complete paper submission
-
 - Any supplementary files
 
 ## Paper Formatting and Page Length

--- a/2025/contribute/workshops.md
+++ b/2025/contribute/workshops.md
@@ -2,7 +2,7 @@
 layout: 2025/page
 title: Call for Workshops
 ---
-*Last updated: 2025-03-17 02:36AM GMT*
+*Last updated: 2025-03-17 2:57AM GMT*
 
 ## Overview
 The ISMAR 2025 organizing committee invites proposals for workshops to be held in conjunction with the ISMAR conference. The workshops will be scheduled on October 8th (Wednesday) and October 12th (Sunday) and can be conducted in person, online, or in hybrid mode, in alignment with the ISMAR conference.
@@ -78,3 +78,5 @@ At least one workshop organizer is required to attend the workshop they are orga
 ---
 
 If you have any questions about this call, please contact: workshops2025@ieeeismar.net
+
+*ISMAR 2025 Workshop Chairs:<br>Jong Weon Lee, Hyungil Kim, Callum Parker, Tobias Schwandt*

--- a/2025/contribute/workshops.md
+++ b/2025/contribute/workshops.md
@@ -77,6 +77,6 @@ At least one workshop organizer is required to attend the workshop they are orga
 
 ---
 
-If you have any questions about this call, please contact: workshops2025@ieeeismar.net
+*If you have any questions about this call, please contact: workshops2025@ieeeismar.net*
 
 *ISMAR 2025 Workshop Chairs:<br>Jong Weon Lee, Hyungil Kim, Callum Parker, Tobias Schwandt*


### PR DESCRIPTION
I was working on updating the workshops contact email on the site, but I noticed that it has already been updated.

So instead, I'm sending you a PR with some minor changes to the details in some of the documents. Please check the Files Changed tab for the detailed changes.