### PR TITLE
post: restore and update 'call for demos'

### DIFF
--- a/2025/committee/organizing.md
+++ b/2025/committee/organizing.md
@@ -409,7 +409,7 @@ redirect_from:
             <div class="chair">
                 <img src="{{ 'assets/2025/img/Committee Members Images/Yongsoon Choi.jpg' | relative_url }}" />
                 <p class="name">Yongsoon Choi</p>
-                <p>Seogang University</p>
+                <p>Sogang University</p>
             </div>
             <div class="chair">
                 <img src="{{ 'assets/2025/img/Committee Members Images/Jin Ryong Kim.jpg' | relative_url }}" />

--- a/2025/contribute/demos.md
+++ b/2025/contribute/demos.md
@@ -16,9 +16,9 @@ The main selection criteria will be the expected general interest of the demonst
 
 ## Important Deadlines
 
-- Submission deadline: August 4th, 2025 (23:59 AoE)
-- Notification: August 18th, 2025 (23:59 AoE)
-- Camera ready deadline: August 22nd, 2025 (23:59 AoE)
+- Submission deadline: July 29th, 2025 (23:59 AoE)
+- Notification: August 13th, 2025 (23:59 AoE)
+- Camera ready deadline: August 20st, 2025 (23:59 AoE)
 
 ## Submission Guidelines
 
@@ -40,4 +40,4 @@ Templates must follow the IEEE Computer Society format at [https://tc.computer.o
 
 *For questions, contact: demo_chairs@ieeeismar.org*
 
-*ISMAR 2025 Demo Chairs:<br>Nilufar Baghaei, Yongsoon Choi, Jin Ryong Kim*
+*ISMAR 2025 Demo Chairs:<br>Nilufar Baghaei, Jin Ryong Kim, Yongsoon Choi*

--- a/_data/2025/navigation.yml
+++ b/_data/2025/navigation.yml
@@ -7,6 +7,8 @@
       url: "2025/contribute/posters"
     - title: Call for Workshops
       url: "2025/contribute/workshops"
+    - title: Call for Demos
+      url: "2025/contribute/demos"
     - title: Call for Tutorials
       url: "2025/contribute/tutorials"
     - title: Guidelines


### PR DESCRIPTION
## Changes

- fix typo, add 'call for demos' page

## Notice

https://github.com/user-attachments/assets/681b97df-c7ff-4bd6-b9c9-59d2b2c8ce20

- In PC mode, there is a bug where the ‘Guideline’ dropdown is not working properly, as shown in the attached video. Please take note of this.
- If my PR conflicts due to the style modification commit, please feel free to mention me. I will update the branch and reflect the conflict-free version in the PR again.