### PR TITLE
[DOCS] Restore info for Hybrid Media Chairs on organizing committee page

### DIFF
--- a/2025/committee/organizing.md
+++ b/2025/committee/organizing.md
@@ -317,12 +317,11 @@ redirect_from:
         <h3>Hybrid Media Chairs</h3>
         <div class="chairs">
 
-            <!-- <div class="chair">
+            <div class="chair">
                 <img src="{{ 'assets/2025/img/Committee Members Images/Isaac Cho.png' | relative_url }}" />
                 <p class="name">Isaac Cho</p>
                 <p>Utah State University</p>
-            </div> -->
-            <!-- Temporarily Hidden according to the chair’s request until mid-April. -->
+            </div>
             <div class="chair">
                 <img src="{{ 'assets/2025/img/Committee Members Images/Jaein Hwang.jpeg' | relative_url }}" />
                 <p class="name">Jaein Hwang</p>


### PR DESCRIPTION
Restore information for the Hybrid Media Chairs section on the organizing committee page, as requested by the chairs.